### PR TITLE
バックエンドでCORSの設定を有効にする

### DIFF
--- a/api/middlewares/cors.go
+++ b/api/middlewares/cors.go
@@ -1,0 +1,26 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// クロスオリジン用にセット
+		// TODO: OriginのURLは本番環境用に環境変数から指定するように変更する
+		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods","GET,PUT,POST,DELETE,UPDATE,OPTIONS")
+		w.Header().Set("Content-Type", "application/json")
+		// プリフライトリクエスト用に200で返す
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		fmt.Println("corst start")
+		next.ServeHTTP(w, r)
+		fmt.Println("corst end")
+	}
+}

--- a/api/middlewares/cors.go
+++ b/api/middlewares/cors.go
@@ -1,7 +1,6 @@
 package middlewares
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -12,15 +11,13 @@ func CorsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Allow-Methods","GET,PUT,POST,DELETE,UPDATE,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,UPDATE,OPTIONS")
 		w.Header().Set("Content-Type", "application/json")
 		// プリフライトリクエスト用に200で返す
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		fmt.Println("corst start")
 		next.ServeHTTP(w, r)
-		fmt.Println("corst end")
 	}
 }

--- a/api/router.go
+++ b/api/router.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/57th-street/oza-gueser/controllers"
 	"github.com/57th-street/oza-gueser/api/middlewares"
+	"github.com/57th-street/oza-gueser/controllers"
 )
 
 func NewRouter() {

--- a/api/router.go
+++ b/api/router.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/57th-street/oza-gueser/controllers"
+	"github.com/57th-street/oza-gueser/api/middlewares"
+)
+
+func NewRouter() {
+	http.HandleFunc("/health", middlewares.CorsMiddleware(controllers.HealthHandler))
+	http.ListenAndServe(":8080", nil)
+}

--- a/controllers/health_controller.go
+++ b/controllers/health_controller.go
@@ -1,0 +1,18 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Response struct {
+	Status  int
+	Message string
+}
+
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("access")
+	response := Response{Status: 200, Message: "succeeded"}
+	json.NewEncoder(w).Encode(response)
+}

--- a/controllers/health_controller.go
+++ b/controllers/health_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -12,7 +11,6 @@ type Response struct {
 }
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("access")
 	response := Response{Status: 200, Message: "succeeded"}
 	json.NewEncoder(w).Encode(response)
 }

--- a/main.go
+++ b/main.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"encoding/json"
-	"net/http"
+	"log"
+
+	"github.com/57th-street/oza-gueser/api"
 )
 
-type Response struct {
-	Status  int
-	Message string
-}
-
-func healthHandler(w http.ResponseWriter, r *http.Request) {
-	response := Response{Status: 200, Message: "succeeded"}
-	json.NewEncoder(w).Encode(response)
-}
-
 func main() {
-	http.HandleFunc("/health", healthHandler)
-	http.ListenAndServe(":8080", nil)
+	api.NewRouter()
+	log.Println("server start at port 8080")
 }


### PR DESCRIPTION
## 概要

フロントエンドとの疎通確認の際にCORSのエラーが発生した。
CORSはJavaScriptを配信しているサーバー(localhost:3000)と異なるサーバーへの通信をブロックする ブラウザのセキュリティー機能です。

フロントエンドからのアクセスを許可するように事前にプリフライトリクエストの際に
バックエンドでヘッダーに許可するオリジン/メソッドを指定する必要がある。

参考：[CORSとは](https://javascript.keicode.com/newjs/what-is-cors.php#4) 
参考: https://qiita.com/popo62520908/items/24956284e40871497082

フロントエンドのエラー
```
Access to XMLHttpRequest at 'http://localhost:3002/test1' from
origin 'http://localhost:3001' has been blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested resource.
```

## 対応内容

- middlewareパターンを利用してCORSを回避するためにレスポンスにヘッダーを付与した
- controllerとmiddlewaresをmain関数から分離するようにリファクタリング