### PR TITLE
テスト環境とローカル環境のDBを分離

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:1.19 as dev
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: login test up migrate
+
+up: ## Start local server
+	docker compose up
+login:  ## Login mysql server
+	mysql -h 127.0.0.1 -u root ozaki --password=pass
+test:  ## Execute local test
+	go test ./...
+help: ## Show options
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/database/migrations/20230709_create_test_database.sql
+++ b/database/migrations/20230709_create_test_database.sql
@@ -1,0 +1,1 @@
+create database test;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,24 @@
 version: '3.3'
 services:
+  app:
+    image: ozaguessr
+    tty: true
+    stdin_open: true
+    build:
+      args:
+        - target=dev
+    environment:
+      DBHost: "127.0.0.1"
+      DBPort: 3306
+      DBUser: root
+      DBPassword: pass
+      DBName: ozaki
+    volumes:
+      - .:/app
+    ports:
+      - 8080:8080
+    depends_on:
+      - mysql
   mysql:
     image: mysql:5.7
     platform: linux/amd64
@@ -12,8 +31,6 @@ services:
         MYSQL_ROOT_USER: ${ROOT_USER}
         MYSQL_ROOT_PASSWORD: ${ROOT_PASS}
         MYSQL_DATABASE: ${DB_NAME}
-        MYSQL_USER: ${DB_USER}
-        MYSQL_PASSWORD: ${DB_PASS}
         TZ: 'Asia/Tokyo'
     ports: 
         - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     tty: true
     stdin_open: true
     build:
+      context: .
       args:
         - target=dev
     environment:

--- a/repositories/main_test.go
+++ b/repositories/main_test.go
@@ -50,7 +50,7 @@ func connectDB() error {
 	}
 	dbUser = os.Getenv("DB_USER")
 	dbPass = os.Getenv("DB_PASS")
-	dbName = os.Getenv("DB_NAME")
+	dbName = "test"
 	dbConn = fmt.Sprintf("%s:%s@tcp(127.0.0.1:3306)/%s?parseTime=true", dbUser, dbPass, dbName)
 	testDB, err = sql.Open("mysql", dbConn)
 	if err != nil {


### PR DESCRIPTION
1. テストを実行する前に次のスクリプトを実行してテスト用のDBを用意してください。

```
mysql -h 127.0.0.1 -u root ozaki --password=pass <
database/migrations/20230709_create_test_database.sql
```

2. .envファイルのDB_USER=root, DB_PASS=pass に書き換えてください。 テスト環境ではrootのユーザーを使用しましょう。

3. テストの実行は下記を試してください

```
make test

```