### PR TITLE
JWT認証の導入

### DIFF
--- a/api/middlewares/auth.go
+++ b/api/middlewares/auth.go
@@ -1,0 +1,46 @@
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/57th-street/oza-gueser/apperrors"
+	"github.com/57th-street/oza-gueser/utils"
+	"github.com/dgrijalva/jwt-go"
+)
+
+type userIDKey struct{}
+
+func AuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		authorization := req.Header.Get("Authorization")
+
+		authHeaders := strings.Split(authorization, " ")
+		if len(authHeaders) != 2 {
+			err := apperrors.RequiredAuthorizationHeader.Wrap(errors.New("invalid request header"), "invalid header")
+			apperrors.ErrorHandler(w, req, err)
+			return
+		}
+
+		bearer, tokenString := authHeaders[0], authHeaders[1]
+		if bearer != "Bearer" || tokenString == "" {
+			err := apperrors.RequiredAuthorizationHeader.Wrap(errors.New("invalid request header"), "invalid header")
+			apperrors.ErrorHandler(w, req, err)
+			return
+		}
+
+		token, err := utils.ValidateToken(tokenString)
+
+		if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+			// このコンテキストをセットする箇所は今後別パッケージに切り出す予定
+			ctx := context.WithValue(req.Context(), userIDKey{}, claims["user_id"])
+			req = req.WithContext(ctx)
+			next.ServeHTTP(w, req)
+		} else {
+			err := apperrors.Unauthorized.Wrap(err, "invalid token")
+			apperrors.ErrorHandler(w, req, err)
+		}
+	})
+}

--- a/api/middlewares/auth.go
+++ b/api/middlewares/auth.go
@@ -32,6 +32,11 @@ func AuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		token, err := utils.ValidateToken(tokenString)
+		if err != nil {
+			err = apperrors.Unauthorized.Wrap(err, "invalid id token")
+			apperrors.ErrorHandler(w, req, err)
+			return
+		}
 
 		if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 			// このコンテキストをセットする箇所は今後別パッケージに切り出す予定

--- a/apperrors/errHandler.go
+++ b/apperrors/errHandler.go
@@ -21,7 +21,7 @@ func ErrorHandler(w http.ResponseWriter, req *http.Request, err error) {
 	switch appErr.ErrCode {
 	case NAData:
 		statusCode = http.StatusNotFound
-	case ReqBodyDecodeFailed, LoginFailed, DataAlreadyExists:
+	case ReqBodyDecodeFailed, DataAlreadyExists:
 		statusCode = http.StatusBadRequest
 	default:
 		statusCode = http.StatusInternalServerError

--- a/apperrors/error_code.go
+++ b/apperrors/error_code.go
@@ -5,16 +5,22 @@ type ErrCode string
 const (
 	Unknown ErrCode = "U000"
 
+	// サービス層のエラー
 	GetDataFailed         ErrCode = "S001"
 	InsertDataFailed      ErrCode = "S002"
 	HashPasswordFailed    ErrCode = "S003"
 	ComparePasswordFailed ErrCode = "S004"
 	CheckDataExistFailed  ErrCode = "S005"
 	NAData                ErrCode = "S006"
+	GenerateTokenFailed   ErrCode = "S007"
 
+	// リクエストエラー
 	ReqBodyDecodeFailed ErrCode = "R001"
 	DataAlreadyExists   ErrCode = "R002"
-	LoginFailed         ErrCode = "R003"
+
+	//　認証エラー
+	RequiredAuthorizationHeader ErrCode = "A001"
+	Unauthorized                ErrCode = "A002"
 )
 
 func (code ErrCode) Wrap(err error, message string) error {

--- a/controllers/services/service.go
+++ b/controllers/services/service.go
@@ -1,6 +1,6 @@
 package services
 
 type AuthServicer interface {
-	Register(email, password string) error
-	Login(email, password string) error
+	Register(email, password string) (int, error)
+	Login(email, password string) (int, error)
 }

--- a/controllers/testdata/mock.go
+++ b/controllers/testdata/mock.go
@@ -6,10 +6,10 @@ func NewServiceMock() *serviceMock {
 	return &serviceMock{}
 }
 
-func (s *serviceMock) Register(email, password string) error {
-	return nil
+func (s *serviceMock) Register(email, password string) (int, error) {
+	return 1, nil
 }
 
-func (s *serviceMock) Login(email, password string) error {
-	return nil
+func (s *serviceMock) Login(email, password string) (int, error) {
+	return 1, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/joho/godotenv v1.5.1
 	golang.org/x/crypto v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	dbUser := os.Getenv("DB_USER")
 	dbPass := os.Getenv("DB_PASS")
 	dbName := os.Getenv("DB_NAME")
-	dbConn := fmt.Sprintf("%s:%s@tcp(127.0.0.1:3306)/%s?parseTime=true", dbUser, dbPass, dbName)
+	dbConn := fmt.Sprintf("%s:%s@tcp(mysql:3306)/%s?parseTime=true", dbUser, dbPass, dbName)
 	db, err := sql.Open("mysql", dbConn)
 	if err != nil {
 		log.Println("fail to connect DB")

--- a/repositories/auth.go
+++ b/repositories/auth.go
@@ -4,6 +4,12 @@ import (
 	"database/sql"
 )
 
+type User struct {
+	ID             int
+	Email          string
+	HashedPassword string
+}
+
 func CheckUserExist(db *sql.DB, email string) (bool, error) {
 	const sqlStr = `select exists (select 1 from users where email = ?);`
 	var exists bool
@@ -11,15 +17,14 @@ func CheckUserExist(db *sql.DB, email string) (bool, error) {
 	return exists, err
 }
 
-func CreateUser(db *sql.DB, email, hashedPassword string) error {
+func CreateUser(db *sql.DB, email, hashedPassword string) (sql.Result, error) {
 	const sqlStr = `insert into users (email, password, created_at) values (?, ?, now()); `
-	_, err := db.Exec(sqlStr, email, hashedPassword)
-	return err
+	return db.Exec(sqlStr, email, hashedPassword)
 }
 
-func GetUserPassword(db *sql.DB, email string) (string, error) {
-	const sqlStr = `select password from users where email = ?;`
-	var hashedPassword string
-	err := db.QueryRow(sqlStr, email).Scan(&hashedPassword)
-	return hashedPassword, err
+func GetUser(db *sql.DB, email string) (User, error) {
+	const sqlStr = `select id, email, password from users where email = ?;`
+	var user User
+	err := db.QueryRow(sqlStr, email).Scan(&user.ID, &user.Email, &user.HashedPassword)
+	return user, err
 }

--- a/repositories/auth_test.go
+++ b/repositories/auth_test.go
@@ -40,16 +40,17 @@ func TestCheckUserExist(t *testing.T) {
 func TestCreateUser(t *testing.T) {
 	email := "test2@test.com"
 	password := "hashedPassword2"
-	err := repositories.CreateUser(testDB, email, password)
+	result, err := repositories.CreateUser(testDB, email, password)
 	if err != nil {
 		t.Error(err)
 	}
-	var actualCount int
-	expectedCount := 1
-	sqlStr := "select count(*) from users where email = ? and password = ?"
-	err = testDB.QueryRow(sqlStr, email, password).Scan(&actualCount)
-	if actualCount != expectedCount {
-		t.Errorf("got %d but want %d", actualCount, expectedCount)
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Error(err)
+	}
+	expectedID := 2
+	if int(id) != expectedID {
+		t.Errorf("got %d but want %d", id, expectedID)
 	}
 	t.Cleanup(func() {
 		const sqlStr = "delete from users where email = ?"
@@ -57,14 +58,21 @@ func TestCreateUser(t *testing.T) {
 	})
 }
 
-func TestGetUserPassword(t *testing.T) {
+func TestGetUser(t *testing.T) {
+	id := testdata.UserTestData.ID
 	email := testdata.UserTestData.Email
 	password := testdata.UserTestData.Password
-	gotPassword, err := repositories.GetUserPassword(testDB, email)
+	user, err := repositories.GetUser(testDB, email)
 	if err != nil {
 		t.Error(err)
 	}
-	if gotPassword != password {
-		t.Errorf("got %s but want %s", gotPassword, password)
+	if int(user.ID) != id {
+		t.Errorf("got %d but want %d", user.ID, id)
+	}
+	if user.Email != email {
+		t.Errorf("got %s but want %s", user.Email, email)
+	}
+	if user.HashedPassword != password {
+		t.Errorf("got %s but want %s", user.HashedPassword, password)
 	}
 }

--- a/services/auth_service_test.go
+++ b/services/auth_service_test.go
@@ -33,9 +33,9 @@ func TestRegister(t *testing.T) {
 	for _, tt := range tests {
 		mock.ExpectQuery(sqlStrCheckUserExist).WithArgs(email).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(tt.userExists))
 		if !tt.userExists {
-			mock.ExpectExec(sqlStrCreateUser).WithArgs(email, password).WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectExec(sqlStrCreateUser).WithArgs(email, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		}
-		err := s.Register(email, password)
+		_, err := s.Register(email, password)
 		if !tt.errIs && err != nil {
 			t.Errorf("unexpected error: %v", err)
 		} else if tt.errIs && err == nil {
@@ -56,16 +56,16 @@ func TestLogin(t *testing.T) {
 		{"successLogin", false, false},
 		{"noData", true, true},
 	}
-	sqlStrGetUserPassword := "select password from users"
+	sqlStrGetUserPassword := "select id, email, password from users"
 	hashedPassword, _ := utils.HashPassword(password)
 
 	for _, tt := range tests {
 		if !tt.noData {
-			mock.ExpectQuery(sqlStrGetUserPassword).WithArgs(email).WillReturnRows(sqlmock.NewRows([]string{"password"}).AddRow(hashedPassword))
+			mock.ExpectQuery(sqlStrGetUserPassword).WithArgs(email).WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password"}).AddRow(1, email, hashedPassword))
 		} else {
 			mock.ExpectQuery(sqlStrGetUserPassword).WithArgs(email).WillReturnError(sql.ErrNoRows)
 		}
-		err := s.Login(email, password)
+		_, err := s.Login(email, password)
 		if !tt.errIs && err != nil {
 			t.Errorf("unexpected error: %v", err)
 		} else if tt.errIs && err == nil {

--- a/utils/jwt.go
+++ b/utils/jwt.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func GenerateToken(userID int) (string, error) {
+	claims := jwt.MapClaims{
+		"user_id": userID,
+		"exp":     time.Now().Add(time.Hour * 24).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	return token.SignedString([]byte(os.Getenv("JWT_SECRET_KEY")))
+}
+
+func ValidateToken(tokenString string) (*jwt.Token, error) {
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return []byte(os.Getenv("JWT_SECRET_KEY")), nil
+	})
+	return token, err
+}


### PR DESCRIPTION
# 主な変更内容
- ログイン成功後、トークンを作成し、それをヘッダのAuthorizationに加えレスポンスとして返す
- AuthMiddlewareを作成し、そこでトークンの検証を行い、認証されたら次のハンドラへ進ませる
- SUTのコード変更に伴い、テストを微調整

# 動作確認
リクエスト例
`curl -i -X POST -d '{"email":"test@test.com","password":"hashedPassword"}' http://localhost:8080/register`

レスポンス例
```
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type
Access-Control-Allow-Methods: GET,PUT,POST,DELETE,UPDATE,OPTIONS
Access-Control-Allow-Origin: http://localhost:3000
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODkyNTIwOTAsInVzZXJfaWQiOjR9.wf72DdSqKT08QV6WQy4NMENR9Ssus_xtkSrICHl0ZNI
Content-Type: application/json
Date: Wed, 12 Jul 2023 12:41:30 GMT
Content-Length: 0
```

# その他
認証が必要なエンドポイントがまだないので、正常に検証できるかは次回テストしようと思います。一旦今は、トークンが期待通りに生成され、それがヘッダに組み込めているかだけ確認しました。