### PR TITLE
usersテーブルのmigrationファイルを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ up: ## Start local server
 	docker compose up
 login:  ## Login mysql server
 	mysql -h 127.0.0.1 -u root ozaki --password=pass
+local-migrate: ## Migrate query disignated by CONFIG path
+	mysql -h 127.0.0.1 -u root ozaki -p < $(CONFIG)
 test:  ## Execute local test
 	go test ./...
 help: ## Show options

--- a/database/migrations/20230811_create_users.sql
+++ b/database/migrations/20230811_create_users.sql
@@ -1,0 +1,9 @@
+create table if not exists users (
+	id integer unsigned auto_increment primary key,
+	email varchar(100) not null,
+	password varchar(100) not null,
+	name varchar(100) default '',
+	image_url varchar(255) default '',
+	intro text default '',
+	created_at datetime
+);


### PR DESCRIPTION
## 概要

migrationファイルを追加。localやprodでmigrationを実行する用のmasterです。
テーブルを作成する際にはmigration配下にスキーマ定義を集約します。

## 実行方法

ローカルでmigrationを走らせるためには次のようなコマンドでファイルを指定して実行します。

```
make local migrate CONFIG=database/migrations/20230811_create_users.sql
```