### PR TITLE
エラーのレスポンスを変更

### DIFF
--- a/apperrors/error.go
+++ b/apperrors/error.go
@@ -1,9 +1,9 @@
 package apperrors
 
 type AppError struct {
-	ErrCode
-	Message string
-	Err     error
+	ErrCode `json:"errCode"`
+	Message string `json:"message"`
+	Err     error  `json:"-"`
 }
 
 func (err AppError) Error() string {

--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -40,8 +40,9 @@ func (c *AuthController) RegisterController(w http.ResponseWriter, req *http.Req
 		apperrors.ErrorHandler(w, req, err)
 		return
 	}
-	w.Header().Set("Authorization", "Bearer "+tokenString)
+	resp := AuthResponse{AccessToken: tokenString}
 	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (c *AuthController) LoginController(w http.ResponseWriter, req *http.Request) {
@@ -62,6 +63,7 @@ func (c *AuthController) LoginController(w http.ResponseWriter, req *http.Reques
 		apperrors.ErrorHandler(w, req, err)
 		return
 	}
-	w.Header().Set("Authorization", "Bearer "+tokenString)
+	resp := AuthResponse{AccessToken: tokenString}
 	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
 }

--- a/controllers/response.go
+++ b/controllers/response.go
@@ -1,0 +1,5 @@
+package controllers
+
+type AuthResponse struct {
+	AccessToken string `json:"accessToken"`
+}

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -35,18 +35,16 @@ paths:
       responses:
         '200':
           description: 作成成功
-          headers:
-            Authorization:
+          content:
+            application/json:
               schema:
-                type: string
-                example: Bareer xxxyyyy
-              description: 認証用のJWTトークン
+                $ref: '#/components/schemas/Auth'
         '400':
           description: リクエストボディが適切ではない
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BadRequest'
+                $ref: '#/components/schemas/Auth'
   '/login':
     post:
       tags:
@@ -69,18 +67,16 @@ paths:
       responses:
         '200':
           description: 認証成功
-          headers:
-            Authorization:
+          content:
+            application/json:
               schema:
-                type: string
-                example: Bareer xxxyyyy
-              description: 認証用のJWTトークン
+                $ref: '#/components/schemas/Auth'
         '400':
           description: リクエストボディが適切ではない
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BadRequest'
+                $ref: '#/components/schemas/Auth'
 components:
   schemas:
     BadRequest:
@@ -101,3 +97,20 @@ components:
         Message:
           type: string
           example: succeeded
+    Auth:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          example: tokenencodedbybase64
+        error:
+          $ref: '#/components/schemas/Error'
+    Error:
+      type: object
+      properties:
+        errCode:
+          type: string
+          example: R001
+        message:
+          type: string
+          example: bad request

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -86,13 +86,10 @@ components:
     BadRequest:
       type: object
       properties:
-        ErrCode:
+        errCode:
           type: string
           example: R001
-        Message:
-          type: string
-          example: bad request
-        Err:
+        message:
           type: string
           example: bad request
     Health:


### PR DESCRIPTION
## 概要

エラーのレスポンスを修正した

## 対応内容

- レスポンスをcamelCaseに統一。フロントエンドで利用するjsのcaseに揃えています。
- Errを表示しないようにした。開発用のエラー（DB情報）などが表示されるためAPIのレスポンスとして返さないようにしています。
- 登録およびログイン時のJWTトークンをBodyで返すようにした
   認証自体はHeaderで良いと思いますが、ログインに対するトークンはBodyの方がフロントエンドで扱いやすいため